### PR TITLE
Update to go 1.18.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.x, 1.18.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,14 +9,18 @@ on:
 jobs:
 
   tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.17.x, 1.18.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: ${{ matrix.go-version }}
 
     - name: Unit Test
       run: go test -v ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: 
-      - "*"
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,8 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches: 
+      - "*"
 
 jobs:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grelay/grelay
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
# Update to go 1.18.0 #3

## Description
Updated go version to use v.1.18, [as promised](https://tip.golang.org/doc/go1compat) code didn't require any modification to be supported in the new version.

## Solution
- Updated go.mod with go 1.18
- Added github actions matrix to test v.1.17 and v1.18 over mac and ubuntu
- Tests validated

## Alternative Solution (optional)
N/A

@edualb 
