### PR TITLE
(refactoring) using context.WithTimeout instead of time.NewTimer

### DIFF
--- a/pkg/grelay/request_test.go
+++ b/pkg/grelay/request_test.go
@@ -118,7 +118,7 @@ func TestGrelayRequestExecWithTwoItemsWithFirstOpenedInQueueShouldReturnNil(t *t
 
 func TestGrelayRequestExecWithOneItemInQueueReturningErrGrelayServiceTimedoutShouldReturnErrGrelayServiceTimedout(t *testing.T) {
 	config := DefaultConfiguration
-	config.Timeout = 11 * time.Millisecond
+	config.Timeout = 10 * time.Millisecond
 	sMock := NewGrelayService(config, mockService{})
 
 	m := map[string]*Service{
@@ -129,7 +129,10 @@ func TestGrelayRequestExecWithOneItemInQueueReturningErrGrelayServiceTimedoutSho
 		Mu:          &sync.RWMutex{},
 	}
 	gr2 = gr2.Enqueue("test", func() (interface{}, error) {
-		time.Sleep(11 * time.Millisecond)
+		// We need to use a big gap here between the timeout configuration (10 - 50 = 40ms of gap).
+		// It is necessary because there is no documented guaranty how precise time is in Go.
+		// We can't assume any precision (especially low) about time.
+		time.Sleep(50 * time.Millisecond)
 		return nil, nil
 	})
 

--- a/pkg/grelay/service_test.go
+++ b/pkg/grelay/service_test.go
@@ -89,12 +89,13 @@ func TestMonitoringWhenStateClosedAndCurrentServiceThreshouldEqualZeroShouldKeep
 	assert.Equal(t, int64(0), g.currentServiceThreshould)
 }
 
-func TestMonitoringWhenStateClosedAndServiceNotOKShouldKeepThreshould(t *testing.T) {
+func TestMonitoringWhenStateClosedAndPingServiceTimedoutShouldKeepThreshould(t *testing.T) {
 	c := DefaultConfiguration
-	c.RetryPeriod = 7 * time.Millisecond
+	c.RetryPeriod = 10 * time.Millisecond
+	c.Timeout = 10 * time.Millisecond
 
-	s := createGrelayService(10*time.Millisecond, nil)
-	c.Timeout = 2 * time.Millisecond
+	s := createGrelayService(50*time.Millisecond, nil)
+
 	g := &Service{
 		config:                   c,
 		state:                    states.Closed,


### PR DESCRIPTION

# Using context.WithTimeout instead of time.NewTimer
Race condition test is failing (timeout error should appear) (#6)

## Description
We noticed that work with time precision is hard with parallel/concurrent program. Go (and many other languages) can't guaranteed the time precision of each goroutine.

## Solution
Golang offer a pattern to deal with timeout
that uses context.WithTimeout function and we are using it now.

Besides that, we increase the gap between the time used in the test
called
`TestGrelayRequestExecWithOneItemInQueueReturningErrGrelayServiceTimedoutShouldReturnErrGrelayServiceTimedout`. Because there is no documented guaranty how precise time is. We must not assume some (especially low) precision.
