### PR TITLE
Increase time gap between timeout configuration and time.Sleep

### DIFF
--- a/pkg/grelay/request_test.go
+++ b/pkg/grelay/request_test.go
@@ -132,7 +132,7 @@ func TestGrelayRequestExecWithOneItemInQueueReturningErrGrelayServiceTimedoutSho
 		// We need to use a big gap here between the timeout configuration (10 - 50 = 40ms of gap).
 		// It is necessary because there is no documented guaranty how precise time is in Go.
 		// We can't assume any precision (especially low) about time.
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(5 * time.Second)
 		return nil, nil
 	})
 

--- a/pkg/grelay/service_test.go
+++ b/pkg/grelay/service_test.go
@@ -94,7 +94,7 @@ func TestMonitoringWhenStateClosedAndPingServiceTimedoutShouldKeepThreshould(t *
 	c.RetryPeriod = 10 * time.Millisecond
 	c.Timeout = 10 * time.Millisecond
 
-	s := createGrelayService(50*time.Millisecond, nil)
+	s := createGrelayService(5*time.Second, nil)
 
 	g := &Service{
 		config:                   c,


### PR DESCRIPTION
# Increase time gap between timeout configuration and time.Sleep

## Description/Solution
We did this change to avoid issues with time and parallel/concurrency.
Because time.Sleep does not guarantee any time precision. So we need to
increase the gap between times.
